### PR TITLE
Remove python2 dependency

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -14,10 +14,10 @@ libev/libev-4.22.tar.gz:
   size: 530094
   object_id: 5d805f33-4078-43f4-7576-2126c5af22ff
   sha: sha256:b7234a886b636e33691b95ba048f008dc79a5c9a02c7535157a90474448dba8c
-pxc/Percona-XtraDB-Cluster-5.7.28-31.41.tar.gz:
-  size: 80210994
-  object_id: 36460057-1e62-440c-4894-2a9aae6e6d4a
-  sha: sha256:11e419efe3d23ec566b20288b4f45e339126932897a363ca348217d2794b25c7
+pxc/Percona-XtraDB-Cluster-5.7.29-31.43.tar.gz:
+  size: 84375983
+  object_id: 49e0cd9c-a856-428d-4c43-26b6fa631d2f
+  sha: sha256:6b158fc70de16ee61cde7fe708d42b18ef1edca93833720c22bf929b2a94494c
 scons/scons-3.0.1.tar.gz:
   size: 634815
   object_id: 4860d0ee-98ef-4bf7-4f75-dc51f18736dd

--- a/packages/libgalera/packaging
+++ b/packages/libgalera/packaging
@@ -2,8 +2,6 @@
 
 set -e -o pipefail
 
-source /var/vcap/packages/python-2.7/bosh/compile.env
-
 set -u
 
 NPROC=$(nproc)
@@ -23,11 +21,11 @@ popd
 
 tar -xf scons/scons-*.tar.gz
 pushd scons-*/
-    python setup.py install --prefix=/usr
+    python3 setup.py install --prefix=/usr
 popd
 
 tar -xf pxc/Percona-XtraDB-Cluster-*.tar.gz
 pushd Percona-XtraDB-Cluster-*/percona-xtradb-cluster-galera
-    HOME=$PWD scons tests=0
+    HOME=$PWD python3 "$(command -v scons)" tests=0
     install --mode=0644 -D libgalera_smm.so "${BOSH_INSTALL_TARGET}/lib/libgalera_smm.so"
 popd

--- a/packages/libgalera/spec
+++ b/packages/libgalera/spec
@@ -1,8 +1,7 @@
 ---
 name: libgalera
 
-dependencies:
-- python-2.7
+dependencies: []
 
 files:
 - boost/boost_1_59_0.tar.gz

--- a/packages/python-2.7/spec.lock
+++ b/packages/python-2.7/spec.lock
@@ -1,2 +1,0 @@
-name: python-2.7
-fingerprint: 7063c9f4e43bf49374c2f6cc6c2f74a5467f2298


### PR DESCRIPTION
# Feature or Bug Description

This removes the bundled python2 build-dependency from pxc-release in favor of using the existing python3 available on modern BOSH stemcells.

# Motivation

python2 is EOL as of January 1st 2020.  The bundled python2 has various vulnerabilities that are otherwise problematic.  This is only a required dependency for the `scons` buildsystem used by the galera replication library as bundled by Percona XtraDB Cluster.   Percona has added support for python3 in the latest release, so python2 is easily removed.
